### PR TITLE
Specify service account in config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Refactored config to use `pydantic` for validation instead of homemade code (#1). 
+- Move service account configuration from env variables to config file. (#7)
+- Refactored config to use `pydantic` for validation instead of homemade code. (#1)
 
 ## [0.2.0] - 2022-03-23
 

--- a/kedro_vertexai/client.py
+++ b/kedro_vertexai/client.py
@@ -87,7 +87,7 @@ class VertexAIPipelinesClient:
             )
 
             run = self.api_client.create_run_from_job_spec(
-                service_account=os.getenv("SERVICE_ACCOUNT"),
+                service_account=self.run_config.service_account,
                 job_spec_path=spec_output.name,
                 job_id=self.run_name,
                 pipeline_root=f"gs://{self.run_config.root}",

--- a/kedro_vertexai/config.py
+++ b/kedro_vertexai/config.py
@@ -25,8 +25,11 @@ run_config:
   # Name of the scheduled run, templated with the schedule parameters
   scheduled_run_name: {run_name}
 
+  # Optional service account to run vertex AI Pipeline with
+  # service_account: pipelines-account@my-project.iam.gserviceaccount.com
+
   # Optional pipeline description
-  #description: "Very Important Pipeline"
+  # description: "Very Important Pipeline"
 
   # How long to keep underlying Argo workflow (together with pods and data
   # volume after pipeline finishes) [in seconds]. Default: 1 week
@@ -91,6 +94,7 @@ class RunConfig(BaseModel):
     description: Optional[str]
     experiment_name: str
     scheduled_run_name: Optional[str]
+    service_account: Optional[str]
     network: Optional[NetworkConfig] = NetworkConfig()
     ttl: int = 3600 * 24 * 7
     resources: Optional[Dict[str, ResourcesConfig]] = dict(
@@ -116,7 +120,6 @@ class PluginConfig(BaseModel):
     project_id: str
     region: str
     run_config: RunConfig
-    service_account: Optional[str]
 
     @staticmethod
     def sample_config(**kwargs):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,15 @@ run_config:
   experiment_name: "Test Experiment"
   scheduled_run_name: "scheduled run"
   description: "My awesome pipeline"
+  service_account: test@pipelines.gserviceaccount.com
   ttl: 300
+  network:
+    vpc: my-vpc
+    host_aliases:
+        - ip: 127.0.0.1
+          hostnames:
+            - myself.local
+            - me.local
   volume:
     storageclass: default
     size: 3Gi
@@ -39,6 +47,16 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.image_pull_policy == "Always"
         assert cfg.run_config.experiment_name == "Test Experiment"
         assert cfg.run_config.scheduled_run_name == "scheduled run"
+        assert (
+            cfg.run_config.service_account
+            == "test@pipelines.gserviceaccount.com"
+        )
+        assert cfg.run_config.network.vpc == "my-vpc"
+        assert str(cfg.run_config.network.host_aliases[0].ip) == "127.0.0.1"
+        assert (
+            "myself.local" in cfg.run_config.network.host_aliases[0].hostnames
+        )
+        assert "me.local" in cfg.run_config.network.host_aliases[0].hostnames
         assert cfg.run_config.resources_for("node1") == {
             "cpu": "500m",
             "memory": "1024Mi",


### PR DESCRIPTION
#### Description

Allow to specify  Vertex AI Pipelines service account via config file rather than env variable

Resolves #7 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
