### PR TITLE
Add KedroContext cache

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Test with tox
       run: |
-        pip install tox-pip-version tox-gh-actions
+        pip install tox-pip-version tox-gh-actions "tox<4.0.0"
         tox -v
 
     - name: Store coverage reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   Add cache to Kedro's context in the `ContextHelper` class to prevent re-loading
 
 ## [0.8.0] - 2022-12-09
 

--- a/kedro_vertexai/context_helper.py
+++ b/kedro_vertexai/context_helper.py
@@ -1,5 +1,5 @@
 import os
-from functools import lru_cache
+from functools import cached_property
 from typing import Any, Dict
 
 from kedro.config import TemplatedConfigLoader
@@ -60,27 +60,25 @@ class ContextHelper(object):
     def project_name(self):
         return self._metadata.project_name
 
-    @property
-    @lru_cache()
+    @cached_property
     def session(self):
         from kedro.framework.session import KedroSession
 
         return KedroSession.create(self._metadata.package_name, env=self._env)
 
-    @property
+    @cached_property
     def context(self):
+        assert self.session is not None, "Session not initialized"
         return self.session.load_context()
 
-    @property
-    @lru_cache()
+    @cached_property
     def config(self) -> PluginConfig:
         raw = EnvTemplatedConfigLoader(self.context.config_loader.conf_source).get(
             self.CONFIG_FILE_PATTERN
         )
         return PluginConfig.parse_obj(raw)
 
-    @property
-    @lru_cache()
+    @cached_property
     def vertexai_client(self) -> VertexAIPipelinesClient:
         return VertexAIPipelinesClient(self.config, self.project_name, self.context)
 


### PR DESCRIPTION
#### Description
Add `cached_property` for Kedro context, as in some cases it was loading it multiple times, causing e.g. `after_context_created` hooks to also be invoked multiple times.


##### PR Checklist
- [ ] ~~Tests added - N/A~~
- [x] [Changelog](CHANGELOG.md) updated 
