### PR TITLE
Revert invalid version change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pytest = "<=7"
 pytest-cov = ">=2.8.0, <4.0.0"
 tox = ">=3.25.1"
 pre-commit = "2.20.0"
-pytest-subtests = ">=0.8.1, <1.0.0"
+pytest-subtests = ">=0.8.0, <1.0.0"
 responses = ">=0.13.4"
 
 [tool.poetry.plugins] # Optional super table


### PR DESCRIPTION
Revert invalid release version change that affected `pytest-subtests`