### PR TITLE
Feature/assign pipelines to experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and it's only available in `kfp-kubernetes` extension package
 - Removed `--timeout-seconds` parameter from `run-once` command for now, as in the old version of the plugin exceeding the specified time
 didn't alter the remote pipeline execution, and only escaped the local Python processs. The timeout funcionality will be added later on,
 with the proper remote pipeline execution handling, and possibly per-task timeout enabled by [the new kfp feature](https://github.com/kubeflow/pipelines/pull/10481).
+- Assign pipelines to Vertex AI experiments
 
 ## [0.11.1] - 2024-07-01
 

--- a/docs/source/02_installation/02_configuration.md
+++ b/docs/source/02_installation/02_configuration.md
@@ -13,8 +13,11 @@ run_config:
   # Location of Vertex AI GCS root
   root: bucket_name/gcs_suffix
 
-  # Name of the kubeflow experiment to be created
+  # Name of the Vertex AI experiment to be created
   experiment_name: MyExperiment
+
+  # Optional description of the Vertex AI experiment to be created
+  # experiment_description: "My experiment description."
 
   # Name of the scheduled run, templated with the schedule parameters
   scheduled_run_name: MyExperimentRun

--- a/kedro_vertexai/client.py
+++ b/kedro_vertexai/client.py
@@ -26,8 +26,12 @@ class VertexAIPipelinesClient:
 
     def __init__(self, config: PluginConfig, project_name, context):
 
-        aip.init(project=config.project_id, location=config.region)
-        self.location = f"projects/{config.project_id}/locations/{config.region}"
+        aip.init(
+            project=config.project_id,
+            location=config.region,
+            experiment=config.run_config.experiment_name,
+            experiment_description=config.run_config.experiment_description,
+        )
         self.run_config = config.run_config
         self.run_name = self._generate_run_name(config)
         self.generator = PipelineGenerator(config, project_name, context, self.run_name)

--- a/kedro_vertexai/client.py
+++ b/kedro_vertexai/client.py
@@ -82,6 +82,7 @@ class VertexAIPipelinesClient:
             job.submit(
                 service_account=self.run_config.service_account,
                 network=self.run_config.network.vpc,
+                experiment=self.run_config.experiment_name,
             )
 
             return job

--- a/kedro_vertexai/config.py
+++ b/kedro_vertexai/config.py
@@ -18,8 +18,11 @@ run_config:
   # Location of Vertex AI GCS root
   root: bucket_name/gcs_suffix
 
-  # Prefix of Vertex AI pipeline run
+  # Name of the Vertex AI experiment to be created
   experiment_name: {project}
+
+  # Optional description of the Vertex AI experiment to be created
+  # experiment_description: "My experiment description."
 
   # Name of the scheduled run, templated with the schedule parameters
   scheduled_run_name: {run_name}
@@ -227,6 +230,7 @@ class RunConfig(BaseModel):
     root: Optional[str]
     description: Optional[str]
     experiment_name: str
+    experiment_description: Optional[str] = None
     scheduled_run_name: Optional[str]
     grouping: Optional[GroupingConfig] = GroupingConfig()
     service_account: Optional[str]

--- a/kedro_vertexai/config.py
+++ b/kedro_vertexai/config.py
@@ -19,7 +19,7 @@ run_config:
   root: bucket_name/gcs_suffix
 
   # Name of the Vertex AI experiment to be created
-  experiment_name: {project}
+  experiment_name: {project}-experiment
 
   # Optional description of the Vertex AI experiment to be created
   # experiment_description: "My experiment description."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ region: some-region
 run_config:
   image: "gcr.io/project-image/test"
   experiment_name: "Test Experiment"
+  experiment_description: "Test Experiment Description."
   scheduled_run_name: "scheduled run"
   description: "My awesome pipeline"
   service_account: test@pipelines.gserviceaccount.com
@@ -100,6 +101,7 @@ run_config:
         cfg = PluginConfig.parse_obj(obj)
         assert cfg.run_config.image == "gcr.io/project-image/test"
         assert cfg.run_config.experiment_name == "Test Experiment"
+        assert cfg.run_config.experiment_description == "Test Experiment Description."
         assert cfg.run_config.scheduled_run_name == "scheduled run"
         assert cfg.run_config.service_account == "test@pipelines.gserviceaccount.com"
         assert cfg.run_config.network.vpc == "my-vpc"


### PR DESCRIPTION
#### Description

The pipelines are now assigned to Vertex AI experiments, utilising existing `experiment_name` and new `experiment_description` parameters from the plugin config.

Resolves #171 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
