### PR TITLE
Add support for Python 3.11 and Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,88 @@
-[tool.poetry]
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[project]
 name = "kedro-vertexai"
 version = "0.11.1"
 description = "Kedro plugin with GCP Vertex AI support"
 readme = "README.md"
-authors = ['Marcin Zabłocki <marcin.zablocki@getindata.com>', 'Mateusz Pytel <mateusz.pytel@getindata.com>', 'Mariusz Strzelecki <mariusz.strzelecki@getindata.com>', 'Artur Dobrogowski <artur.dobrogowski@getindata.com>']
-maintainers = ['GetInData MLOPS <mlops@getindata.com>']
+authors = [
+    {name = "Marcin Zabłocki", email = "marcin.zablocki@getindata.com"},
+    {name = "Mateusz Pytel", email = "mateusz.pytel@getindata.com"},
+    {name = "Mariusz Strzelecki", email = "mariusz.strzelecki@getindata.com"},
+    {name = "Artur Dobrogowski", email = "artur.dobrogowski@getindata.com"},
+]
+maintainers = [
+    {name = "GetInData MLOPS", email = "mlops@getindata.com"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<3.11,>=3.8"
+dependencies = [
+    "kedro<0.20,>=0.19.0",
+    "click>=8.0.4",
+    "kfp<3.0,>=2.0.0",
+    "tabulate>=0.8.7",
+    "semver<4.0.0,>=2.10",
+    "toposort<2.0,>1.0",
+    "pyarrow>=14.0.1",
+    "pydantic<3,>=2",
+    "google-auth<3",
+    "google-cloud-scheduler>=2.3.2",
+    "google-cloud-iam<3",
+    "gcsfs>=2022.1",
+    "fsspec>=2022.1",
+    "google-cloud-storage<3.0.0",
+    "grpcio<2.0.0,>=1.4.0",
+    "grpcio-status<2.0.0,>=1.4.0",
+    "protobuf<21.0,>=3.18.0",
+    "cachetools<6.0,>=3.0",
+    "google-cloud-aiplatform[metadata]<2.0.0,>=1.59.0",
+    "cloudpickle<4.0.0,>=3.0.0",
+    "mlflow<3.0.0,>=2.14.3",
+]
+keywords = [
+    "kedro-plugin",
+    "kedro",
+    "mlops",
+    "vertexai",
+    "googlecloudplatform",
+    "machinelearning",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+]
+
+[project.urls]
 homepage = "https://github.com/getindata/kedro-vertexai"
 repository = "https://github.com/getindata/kedro-vertexai"
 documentation = "https://kedro-vertexai.readthedocs.io/"
-keywords = ['kedro-plugin', 'kedro', 'mlops', 'vertexai', 'googlecloudplatform', 'machinelearning']
-license = "Apache-2.0"
-classifiers = [
-    "Development Status :: 4 - Beta", # license and python versions added automatically
+
+[project.entry-points."kedro.project_commands"]
+vertexai = "kedro_vertexai.cli:commands"
+
+[project.entry-points."kedro.hooks"]
+vertexai_mlflow_tags_hook = "kedro_vertexai.hooks:mlflow_tags_hook"
+
+[project.entry-points."mlflow.request_header_provider"]
+unused = "kedro_vertexai.auth.mlflow_request_header_provider:DynamicMLFlowRequestHeaderProvider"
+
+[project.optional-dependencies]
+mlflow = [
+    "kedro-mlflow<0.13,>=0.12.1",
+]
+[tool.pdm.dev-dependencies]
+dev = [
+    "pytest<=8.0.2",
+    "pytest-cov<4.0.0,>=2.8.0",
+    "tox<4.0.0,>=3.25.1",
+    "pre-commit==2.20.0",
+    "pytest-subtests<1.0.0,>=0.8.0",
+    "responses>=0.13.4",
 ]
 
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.pdm.build]
+includes = []
 
 [tool.coverage.run]
 branch = true
@@ -30,51 +96,3 @@ exclude_lines = [
 
 [tool.isort]
 known_third_party = ["click","google","kedro","kfp","kubernetes","tabulate", "pydantic","semver","setuptools"]
-
-[tool.poetry.dependencies]
-python = ">=3.8,<3.11" # weird error OverrideNeeded when bumping up. Could be related to old versions with kfp
-kedro = ">=0.19.0,<0.20"
-click = ">=8.0.4"
-kfp = ">=2.0.0,<3.0"
-tabulate = ">=0.8.7"
-semver = ">=2.10,<4.0.0"
-toposort = ">1.0,<2.0"
-pyarrow = ">=14.0.1" # Stating explicitly for sub-dependency due to critical vulnerability
-pydantic = ">=2,<3"
-google-auth = "<3"
-google-cloud-scheduler = ">=2.3.2"
-google-cloud-iam = "<3"
-gcsfs = ">=2022.1"
-fsspec = ">=2022.1"
-google-cloud-storage = "<3.0.0"
-grpcio = ">=1.4.0,<2.0.0"
-grpcio-status = ">=1.4.0,<2.0.0"
-protobuf = ">=3.18.0,<21.0"
-kedro-mlflow = {version = ">=0.12.1,<0.13", optional = true}
-cachetools = ">=3.0,<6.0"
-# pyaml in version 5 does problems with installing binaries/wheel in cicd env with python 3.10. The following fixes that:
-# pyyaml = ">=6.0,<7"
-google-cloud-aiplatform = {extras = ["metadata"], version = "^1.59.0"}
-cloudpickle = "^3.0.0"
-mlflow = "^2.14.3"
-
-[tool.poetry.extras]
-mlflow = ["kedro-mlflow"]
-
-[tool.poetry.dev-dependencies]
-pytest = "<=8.0.2"
-pytest-cov = ">=2.8.0, <4.0.0"
-tox = ">=3.25.1,<4.0.0"
-pre-commit = "2.20.0"
-pytest-subtests = ">=0.8.0, <1.0.0"
-responses = ">=0.13.4"
-
-[tool.poetry.plugins] # Optional super table
-[tool.poetry.plugins."kedro.project_commands"]
-"vertexai" = "kedro_vertexai.cli:commands"
-
-[tool.poetry.plugins."kedro.hooks"]
-"vertexai_mlflow_tags_hook" = "kedro_vertexai.hooks:mlflow_tags_hook"
-
-[tool.poetry.plugins."mlflow.request_header_provider"]
-"unused" = "kedro_vertexai.auth.mlflow_request_header_provider:DynamicMLFlowRequestHeaderProvider"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
     {name = "GetInData MLOPS", email = "mlops@getindata.com"},
 ]
 license = {text = "Apache-2.0"}
-requires-python = "<3.11,>=3.8"
+requires-python = ">=3.8"
 dependencies = [
     "kedro<0.20,>=0.19.0",
     "click>=8.0.4",


### PR DESCRIPTION
#### Description

Add support for Python 3.11 and, in turn, 3.12 too.

I completely lifted the upper version cap for the Python version. See:
- https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
- https://discuss.python.org/t/requires-python-upper-limits/12663
- https://github.com/pypa/packaging.python.org/pull/1274/

The side effect of that is that users may _attempt_ to install on Python 3.13, but since there are no precompiled wheels of `pyarrow==17.0.0` it will fail unless the user system has the necessary dependencies. This doesn't mean that it isn't technically possible to use `kedro-vertexai` on Python 3.13, it's just that I haven't tried. The user would get a warning coming from Kedro anyway, see https://github.com/kedro-org/kedro/pull/2742 🔶 

I also added 3.11 and 3.12 to the test matrix.

Resolves #139, resolves #146 

I think the errors observed by @Lasica in #146 were due to Poetry bugs and not necessarily dependency incompatibilities. So I ran `pdm import` to migrate the project metadata to PEP 621 (the only reason I chose PDM was because such `import` command existed, with a trivial change this can be migrated to Hatch or any other PEP 621-compliant workflow tool). This doesn't have user impact.

##### PR Checklist
- [ ] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
