### PR TITLE
Migrate to upload artifact v4.

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -44,7 +44,7 @@ jobs:
         tox -v
 
     - name: Store coverage reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ matrix.python-version }}
         path: coverage.xml
@@ -59,7 +59,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: coverage-3.9
         path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ didn't alter the remote pipeline execution, and only escaped the local Python pr
 with the proper remote pipeline execution handling, and possibly per-task timeout enabled by [the new kfp feature](https://github.com/kubeflow/pipelines/pull/10481).
 - Assign pipelines to Vertex AI experiments
 - Migrated `pydantic` library to v2
+- Migrated to `actions/upload-artifact@v4` in the Github Actions
 
 ## [0.11.1] - 2024-07-01
 


### PR DESCRIPTION
#### Description

As the `actions/upload-artifact@v3` got deprecated ([link](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)), it was necessary to reimplement the CI steps to use the v4 instead.

##### PR Checklist
- [ ] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
